### PR TITLE
Fix #25

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bs-fullscreen-message": "Kikobeats/bs-fullscreen-message",
     "lodash": "4.x.x",
-    "strip-ansi": "~3.0.1"
+    "ansi-to-html": "^0.4.2"
   },
   "devDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
I've made some modification : 
- html error instead of txt one : webpack error is unreadable, need some color :smile:
- reload happen all the time in my case also when there is an error (I have the feeling that we don't include the plugins the same way)

In my case, all is working very well, and it avoid me to use : [webpack-notifier](https://github.com/Turbo87/webpack-notifier) that don't work anymore in a docker environnement, really thank for the work
